### PR TITLE
tweak html header meta data; remove initial scale=1. with the initial…

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Great Idea - Responsive I</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width" />
     <link
       href="https://fonts.googleapis.com/css?family=Bangers|Titillium+Web"
       rel="stylesheet"


### PR DESCRIPTION
… scale set to 1 the mobile view was displaying zoomed in on first load